### PR TITLE
Add support for ext0/1/2/3 registers

### DIFF
--- a/clang-tools-extra/clangd/Shutdown.cpp
+++ b/clang-tools-extra/clangd/Shutdown.cpp
@@ -10,6 +10,7 @@
 
 #include <atomic>
 #include <thread>
+#include <cstdlib>
 
 namespace clang {
 namespace clangd {

--- a/lldb/source/API/SystemInitializerFull.cpp
+++ b/lldb/source/API/SystemInitializerFull.cpp
@@ -162,6 +162,7 @@ SystemInitializerFull::~SystemInitializerFull() {}
 #define LLDB_PROCESS_Sparc(op)
 #define LLDB_PROCESS_WebAssembly(op)
 #define LLDB_PROCESS_XCore(op)
+#define LLDB_PROCESS_Teak(op)
 
 llvm::Error SystemInitializerFull::Initialize() {
   if (auto e = SystemInitializerCommon::Initialize())

--- a/lldb/tools/lldb-test/SystemInitializerTest.cpp
+++ b/lldb/tools/lldb-test/SystemInitializerTest.cpp
@@ -145,6 +145,7 @@ SystemInitializerTest::~SystemInitializerTest() {}
 #define LLDB_PROCESS_Sparc(op)
 #define LLDB_PROCESS_WebAssembly(op)
 #define LLDB_PROCESS_XCore(op)
+#define LLDB_PROCESS_Teak(op)
 
 llvm::Error SystemInitializerTest::Initialize() {
   if (auto e = SystemInitializerCommon::Initialize())

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -3870,7 +3870,7 @@ void SelectionDAGBuilder::visitGetElementPtr(const User &I) {
   // element which holds a pointer.
   unsigned AS = Op0->getType()->getScalarType()->getPointerAddressSpace();
   SDValue N = getValue(Op0);
-  N.dump();
+  //N.dump();
   SDLoc dl = getCurSDLoc();
   auto &TLI = DAG.getTargetLoweringInfo();
   MVT PtrTy = TLI.getPointerTy(DAG.getDataLayout(), AS);
@@ -4010,7 +4010,7 @@ void SelectionDAGBuilder::visitGetElementPtr(const User &I) {
   if (PtrMemTy != PtrTy && !cast<GEPOperator>(I).isInBounds())
     N = DAG.getPtrExtendInReg(N, dl, PtrMemTy);
 
-  DAG.dump();
+  //DAG.dump();
 
   setValue(&I, N);
 }

--- a/llvm/lib/Target/Teak/AsmParser/disassembler.cpp
+++ b/llvm/lib/Target/Teak/AsmParser/disassembler.cpp
@@ -151,6 +151,16 @@ std::string DsmReg(RegName a) {
         return "st1";
     case RegName::st2:
         return "st2";
+		
+	case RegName::ext0:
+		return "ext0";	
+	case RegName::ext1:
+		return "ext1";	
+	case RegName::ext2:
+		return "ext2";	
+	case RegName::ext3:
+		return "ext3";
+		
     default:
         return "[ERROR]" + std::to_string((int)a);
     }

--- a/llvm/lib/Target/Teak/AsmParser/disassembler.cpp
+++ b/llvm/lib/Target/Teak/AsmParser/disassembler.cpp
@@ -152,14 +152,14 @@ std::string DsmReg(RegName a) {
     case RegName::st2:
         return "st2";
 		
-	case RegName::ext0:
-		return "ext0";	
-	case RegName::ext1:
-		return "ext1";	
-	case RegName::ext2:
-		return "ext2";	
-	case RegName::ext3:
-		return "ext3";
+    case RegName::ext0:
+        return "ext0";	
+    case RegName::ext1:
+        return "ext1";	
+    case RegName::ext2:
+        return "ext2";	
+    case RegName::ext3:
+        return "ext3";
 		
     default:
         return "[ERROR]" + std::to_string((int)a);

--- a/llvm/lib/Target/Teak/TeakISelDAGToDAG.cpp
+++ b/llvm/lib/Target/Teak/TeakISelDAGToDAG.cpp
@@ -136,7 +136,7 @@ bool TeakDAGToDAGISel::SelectLoad(SDNode* node)
 	const LoadSDNode* ld = cast<LoadSDNode>(node);
 	ISD::MemIndexedMode idxMode = ld->getAddressingMode();
   	MVT vType = ld->getMemoryVT().getSimpleVT();
-	ld->dump();
+	//ld->dump();
 	dbgs() << "mode: " << idxMode << "\n";
 	if(idxMode != ISD::POST_INC && idxMode != ISD::POST_DEC)
 		return false;

--- a/llvm/lib/Target/Teak/TeakISelLowering.cpp
+++ b/llvm/lib/Target/Teak/TeakISelLowering.cpp
@@ -438,7 +438,7 @@ SDValue TeakTargetLowering::LowerOperation(SDValue Op, SelectionDAG &DAG) const
 	switch (Op.getOpcode()) 
 	{
 		default:
-			Op.dump(&DAG);
+			//Op.dump(&DAG);
 			llvm_unreachable("Unimplemented operand");
 	//case ISD::SELECT:        return LowerSELECT(Op, DAG);
 		case ISD::SELECT_CC:
@@ -965,8 +965,8 @@ void TeakTargetLowering::ReplaceNodeResults(SDNode *N,
 											SelectionDAG &DAG) const
 {
 	dbgs() << "Opcode = " << N->getOpcode();
-	DAG.dump();
-	N->dumpr(&DAG);
+	//DAG.dump();
+	//N->dumpr(&DAG);
 	SDLoc dl(N);
 	// if(N->getOpcode() == ISD::GlobalAddress)
 	// {

--- a/llvm/lib/Target/Teak/TeakRegisterInfo.cpp
+++ b/llvm/lib/Target/Teak/TeakRegisterInfo.cpp
@@ -226,7 +226,7 @@ void TeakRegisterInfo::materializeFrameBaseRegister(MachineBasicBlock *MBB,
 void TeakRegisterInfo::resolveFrameIndex(MachineInstr &MI, unsigned BaseReg, int64_t Offset) const
 {
     dbgs() << "resolveFrameIndex\n";
-    MI.dump();
+    //MI.dump();
     const MachineFunction &MF = *MI.getParent()->getParent();
     const MachineFrameInfo& MFI = MF.getFrameInfo();
     MachineOperand* FIOp;
@@ -263,7 +263,7 @@ bool TeakRegisterInfo::shouldCoalesce(MachineInstr *MI, const TargetRegisterClas
     const TargetRegisterClass *DstRC, unsigned DstSubReg, const TargetRegisterClass *NewRC, LiveIntervals &LIS) const
 {
     dbgs() << "shouldCoalesce\n";
-    MI->dump();
+    //MI->dump();
     dbgs() << "SrcRC: " << SrcRC->getID() << "\n";
     dbgs() << "SubReg: " << SubReg << "\n";
     dbgs() << "DstRC: " << DstRC->getID() << "\n";

--- a/llvm/utils/benchmark/src/benchmark_register.h
+++ b/llvm/utils/benchmark/src/benchmark_register.h
@@ -2,6 +2,7 @@
 #define BENCHMARK_REGISTER_H
 
 #include <vector>
+#include <limits>
 
 #include "check.h"
 


### PR DESCRIPTION
Several instructions (those who can take a variety of registers, denoted by 'Register' and 'RegisterP0' operand types on GBAtek) can operate on ext0/1/2/3. However, the function used to parse register names didn't handle these.